### PR TITLE
Removed the "use_hash" hint when making geospatial queries for results.

### DIFF
--- a/src/main/resources/mybatis/bioResult.xml
+++ b/src/main/resources/mybatis/bioResult.xml
@@ -6,8 +6,7 @@
         <if test="minactivities != null or minresults != null">
             select * from (
         </if>
-        select <include refid="dynamicWhere.resultStationHashHint"/>
-               <include refid="base.baseColumns"/>,
+        select <include refid="base.baseColumns"/>,
                <include refid="activity.baseColumns"/>,
                <include refid="narrowResult.baseColumns"/>,
                <include refid="resFreqClass.baseColumns"/>,

--- a/src/main/resources/mybatis/dynamicResult.xml
+++ b/src/main/resources/mybatis/dynamicResult.xml
@@ -3,12 +3,6 @@
 
 <mapper namespace="dynamicWhere">
 
-    <sql id="resultStationHashHint">
-        <if test="bBox != null or within != null">
-            /*+ use_hash(prime) use_hash(secondary) */
-        </if>
-    </sql>
-
     <sql id="baseWhereResultClauses">
         <include refid="dynamicWhere.baseWhereActivityClauses" />
         <if test="analyticalmethod != null">

--- a/src/main/resources/mybatis/narrowResult.xml
+++ b/src/main/resources/mybatis/narrowResult.xml
@@ -22,8 +22,7 @@
         <if test="minactivities != null or minresults != null">
             select * from (
         </if>
-        select <include refid="dynamicWhere.resultStationHashHint"/>
-               <include refid="base.baseColumns"/>,
+        select <include refid="base.baseColumns"/>,
                <include refid="activity.baseColumns"/>,
                <include refid="narrowResult.baseColumns"/>,
                prime.analytical_method,

--- a/src/main/resources/mybatis/pcResult.xml
+++ b/src/main/resources/mybatis/pcResult.xml
@@ -6,8 +6,7 @@
         <if test="minactivities != null or minresults != null">
             select * from (
         </if>
-        select <include refid="dynamicWhere.resultStationHashHint"/>
-               <include refid="base.baseColumns"/>,
+        select <include refid="base.baseColumns"/>,
                to_char(prime.event_date, 'yyyy-mm-dd') event_date, prime.p_code, prime.activity,
                prime.characteristic_name, prime.characteristic_type, prime.sample_media, prime.site_type, prime.huc, prime.governmental_unit_code, prime.activity_id,
                prime.activity_type_code, prime.activity_media_subdiv_name, prime.activity_start_time,


### PR DESCRIPTION
This decreased the response time of the queries from roughly 7 minutes to 20 seconds for both the bbox and radius queries.