### PR TITLE
Wqp 1597

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased](https://github.com/NWQMC/WQP-WQX-Services/compare/WQP-WQX-Services/compare/WQP-WQX-Services-1.6.0...master)
 ## Changed
 -   Performance improvement on searches when specifying project
+-   Increase work_mem on result queries to reduce timeouts
 
 ## [1.6.0](https://github.com/NWQMC/WQP-WQX-Services/compare/WQP-WQX-Services/compare/WQP-WQX-Services-1.6.0...master) - 2020-07-13
 ### Added

--- a/src/main/resources/mybatis/result.xml
+++ b/src/main/resources/mybatis/result.xml
@@ -77,6 +77,7 @@
 
     <sql id="pre">
         <if test="minresults != null">
+            set work_mem='128MB';
             select * from (
         </if>
     </sql>

--- a/src/main/resources/mybatis/result.xml
+++ b/src/main/resources/mybatis/result.xml
@@ -103,6 +103,7 @@
                      prime.activity,
                      prime.result_id
         </if>
+        ; reset work_mem;
     </sql>
 
     <sql id="resultCount">

--- a/src/main/resources/mybatis/result.xml
+++ b/src/main/resources/mybatis/result.xml
@@ -77,7 +77,7 @@
 
     <sql id="pre">
         <if test="minresults != null">
-            set work_mem='128MB';
+            set work_mem='32MB';
             select * from (
         </if>
     </sql>

--- a/src/main/resources/mybatis/result.xml
+++ b/src/main/resources/mybatis/result.xml
@@ -77,7 +77,6 @@
 
     <sql id="pre">
         <if test="minresults != null">
-            set work_mem='32MB';
             select * from (
         </if>
     </sql>
@@ -103,7 +102,6 @@
                      prime.activity,
                      prime.result_id
         </if>
-        ; reset work_mem;
     </sql>
 
     <sql id="resultCount">

--- a/src/main/resources/mybatis/result.xml
+++ b/src/main/resources/mybatis/result.xml
@@ -76,6 +76,7 @@
     </sql>
 
     <sql id="pre">
+        set work_mem='32MB';
         <if test="minresults != null">
             select * from (
         </if>
@@ -102,6 +103,7 @@
                      prime.activity,
                      prime.result_id
         </if>
+        ; reset work_mem;
     </sql>
 
     <sql id="resultCount">

--- a/src/main/resources/mybatis/resultPhysChem.xml
+++ b/src/main/resources/mybatis/resultPhysChem.xml
@@ -21,11 +21,11 @@
     </sql>
 
     <select id="select" resultType="java.util.LinkedHashMap" fetchSize="500">
-        set work_mem='32MB';
+
         <include refid="result.pre"/>
         select <include refid="resultPhysChem.baseColumns"/>
         <include refid="result.post"/>
-        ; reset work_mem;
+
     </select>
 
     <select id="count" resultType="java.util.LinkedHashMap">

--- a/src/main/resources/mybatis/resultPhysChem.xml
+++ b/src/main/resources/mybatis/resultPhysChem.xml
@@ -21,9 +21,11 @@
     </sql>
 
     <select id="select" resultType="java.util.LinkedHashMap" fetchSize="500">
+        set work_mem='32MB';
         <include refid="result.pre"/>
         select <include refid="resultPhysChem.baseColumns"/>
         <include refid="result.post"/>
+        ; reset work_mem;
     </select>
 
     <select id="count" resultType="java.util.LinkedHashMap">


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
For all the result queries, start by changing the work_mem to 32mb, and finish by resetting it to the default of 4 mb.  This should enhance the performance all result queries that are struggling with sorting or using indexes properly (aka "lossy heap blocks").

Description
-----------
Originally I tried to set this at the database level but ran into a couple problems:

1. the request to alter a system setting in postgres.sql cannot be run in a transaction, so we can't do it at Jenkins time.  
2. changing this value globally is considered to be a little risky and setting it at the db session or query level is considered the safer alternative.

I verified this approach works on test -- the query on characteristic_name in ('Fecal Coliform') completes successfully now, was timing out previously.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
