### PR TITLE
boost work_mem to 64mb (WQP-1597)

### DIFF
--- a/src/main/resources/mybatis/result.xml
+++ b/src/main/resources/mybatis/result.xml
@@ -76,7 +76,7 @@
     </sql>
 
     <sql id="pre">
-        set work_mem='32MB';
+        set work_mem='64MB';
         <if test="minresults != null">
             select * from (
         </if>


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
The previous fix for WQP-1597 boosted work_mem from 4 mb to 32 mb.  It turns out that 32 mb is a bit borderline.  It worked 3 days in a row, then didn't work.  Boost to 64 mb.  See ticket for time tests.

Description
-----------


After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
